### PR TITLE
Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: perl
-perl:
- - "5.10"
- - "5.12"
- - "5.14"
- - "5.16"
- - "5.18"
+matrix:
+  include:
+  - perl: "5.10"
+    dist: trusty
+  - perl: "5.12"
+    dist: trusty
+  - perl: "5.14"
+    dist: trusty
+  - perl: "5.16"
+    dist: trusty
+  - perl: "5.18"
+    dist: trusty
+  - perl: "5.20"
+    dist: trusty
+  - perl: "5.22"
+  - perl: "5.24"
+  - perl: "5.26"
+  - perl: "5.28"
+  - perl: "5.30"
 before_script:
  - "git config --global user.email 'you@example.com'"
  - "git config --global user.name 'Your Name'"

--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'File::Spec';
 requires 'File::Temp';
 requires 'Git::Repository', '1.13';
 requires 'Test::More', '0.94';
+requires 'Test::Fatal';
 
 on 'develop' => sub {
     requires 'Archive::Tar::Wrapper';


### PR DESCRIPTION
Hello! This is from [pullrequest.club](https://pullrequest.club).

Here is a small update to the travis setup. The default build environment is now Xenial (Ubuntu 16.04) where `perl` versions before 5.22 are not available. So I added `dist` keyword to `.travis.yml` to build on older versions (before 5.22). Also, it seems `Test::Fatal` is not automatically installed (?) on 5.10 and 5.12, so added to `cpanfile`.